### PR TITLE
TEC-XXXX: add exportSchemaArray, which puts all the schemas into an a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ $ openapi --help
     --exportServices <value>  Write services to disk (default: true)
     --exportModels <value>    Write models to disk (default: true)
     --exportSchemas <value>   Write schemas to disk (default: false)
+    --exportSchemaArray <value>   Put all schemas into array (default: false)
     --indent <value>          Indentation options [4, 2, tab] (default: "4")
     --postfixServices         Service name postfix (default: "Service")
     --postfixModels           Model name postfix

--- a/bin/index.js
+++ b/bin/index.js
@@ -20,6 +20,7 @@ const params = program
     .option('--exportServices <value>', 'Write services to disk', true)
     .option('--exportModels <value>', 'Write models to disk', true)
     .option('--exportSchemas <value>', 'Write schemas to disk', false)
+    .option('--exportSchemaArray <value>', 'Write an array of the schemas to disk', false)
     .option('--indent <value>', 'Indentation options [4, 2, tabs]', '4')
     .option('--postfixServices <value>', 'Service name postfix', 'Service')
     .option('--postfixModels <value>', 'Model name postfix')
@@ -41,6 +42,7 @@ if (OpenAPI) {
         exportServices: JSON.parse(params.exportServices) === true,
         exportModels: JSON.parse(params.exportModels) === true,
         exportSchemas: JSON.parse(params.exportSchemas) === true,
+        exportSchemaArray: JSON.parse(params.exportSchemaArray) === true,
         indent: params.indent,
         postfixServices: params.postfixServices,
         postfixModels: params.postfixModels,

--- a/bin/index.spec.js
+++ b/bin/index.spec.js
@@ -32,6 +32,8 @@ describe('bin', () => {
             'true',
             '--exportSchemas',
             'true',
+            '--exportSchemaArray',
+            'false',
             '--indent',
             '4',
             '--postfixServices',

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export type Options = {
     exportServices?: boolean;
     exportModels?: boolean;
     exportSchemas?: boolean;
+    exportSchemaArray?: boolean;
     indent?: Indent;
     postfixServices?: string;
     postfixModels?: string;
@@ -44,6 +45,7 @@ export type Options = {
  * @param exportServices Generate services
  * @param exportModels Generate models
  * @param exportSchemas Generate schemas
+ * @param exportSchemaArray List schemas in an array
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
@@ -61,6 +63,7 @@ export const generate = async ({
     exportServices = true,
     exportModels = true,
     exportSchemas = false,
+    exportSchemaArray = false,
     indent = Indent.SPACE_4,
     postfixServices = 'Service',
     postfixModels = '',
@@ -91,6 +94,7 @@ export const generate = async ({
                 exportServices,
                 exportModels,
                 exportSchemas,
+                exportSchemaArray,
                 indent,
                 postfixServices,
                 postfixModels,
@@ -115,6 +119,7 @@ export const generate = async ({
                 exportServices,
                 exportModels,
                 exportSchemas,
+                exportSchemaArray,
                 indent,
                 postfixServices,
                 postfixModels,

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -41,7 +41,7 @@ export { ${{{name}}} } from './schemas/${{{name}}}';
 import { ${{{name}}} } from './schemas/${{{name}}}';
 {{/each}}
 
-export const AllSchemas = [{{#each models}} { ${{{name}}} } ,{{/each}}];
+export const allSchemas = [{{#each models}} { ${{{name}}} } ,{{/each}}];
 {{/if}}
 
 {{/if}}

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -35,6 +35,15 @@ export type { {{{name}}}{{#if @root.postfixModels}} as {{{name}}}{{{@root.postfi
 {{#each models}}
 export { ${{{name}}} } from './schemas/${{{name}}}';
 {{/each}}
+
+{{#if @root.exportSchemaArray}}
+{{#each models}}
+import { ${{{name}}} } from './schemas/${{{name}}}';
+{{/each}}
+
+export const AllSchemas = [{{#each models}} { ${{{name}}} } ,{{/each}}];
+{{/if}}
+
 {{/if}}
 {{/if}}
 {{#if @root.exportServices}}

--- a/src/utils/writeClient.spec.ts
+++ b/src/utils/writeClient.spec.ts
@@ -47,6 +47,7 @@ describe('writeClient', () => {
             true,
             true,
             true,
+            false,
             Indent.SPACE_4,
             'Service',
             'AppClient'

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -26,7 +26,7 @@ import { writeClientServices } from './writeClientServices';
  * @param exportServices Generate services
  * @param exportModels Generate models
  * @param exportSchemas Generate schemas
- * @param exportSchemas Generate schemas
+ * @param exportSchemaArray List schemas in an array
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
@@ -44,6 +44,7 @@ export const writeClient = async (
     exportServices: boolean,
     exportModels: boolean,
     exportSchemas: boolean,
+    exportSchemaArray: boolean,
     indent: Indent,
     postfixServices: string,
     postfixModels: string,
@@ -110,6 +111,7 @@ export const writeClient = async (
             exportServices,
             exportModels,
             exportSchemas,
+            exportSchemaArray,
             postfixServices,
             postfixModels,
             clientName

--- a/src/utils/writeClientIndex.spec.ts
+++ b/src/utils/writeClientIndex.spec.ts
@@ -36,7 +36,7 @@ describe('writeClientIndex', () => {
             },
         };
 
-        await writeClientIndex(client, templates, '/', true, true, true, true, true, 'Service', '');
+        await writeClientIndex(client, templates, '/', true, true, true, true, true, false, 'Service', '');
 
         expect(writeFile).toBeCalledWith(resolve('/', '/index.ts'), 'index');
     });

--- a/src/utils/writeClientIndex.ts
+++ b/src/utils/writeClientIndex.ts
@@ -19,6 +19,7 @@ import { sortServicesByName } from './sortServicesByName';
  * @param exportServices Generate services
  * @param exportModels Generate models
  * @param exportSchemas Generate schemas
+ * @param exportSchemaArray List schemas in an array
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
  * @param clientName Custom client class name
@@ -32,6 +33,7 @@ export const writeClientIndex = async (
     exportServices: boolean,
     exportModels: boolean,
     exportSchemas: boolean,
+    exportSchemaArray: boolean,
     postfixServices: string,
     postfixModels: string,
     clientName?: string
@@ -41,6 +43,7 @@ export const writeClientIndex = async (
         exportServices,
         exportModels,
         exportSchemas,
+        exportSchemaArray,
         useUnionTypes,
         postfixServices,
         postfixModels,


### PR DESCRIPTION
- We need to be able to feed a list of all of our schemas into Z-Schema for validation of uploaded JSON files
- We want this process to happen automatically for new/modified/deleted items
- Therefore, add exportSchemaArray, which exports all the schemas into a list that can be consumed by Z-Schema